### PR TITLE
fix: error handeling for kvtj command

### DIFF
--- a/cmd/keyValueToJson.go
+++ b/cmd/keyValueToJson.go
@@ -33,8 +33,22 @@ var keyValueToJson = &cobra.Command{
 		entries := strings.Split(string(content), "\n")
 		m := make(map[string]string)
 		for _, e := range entries {
+
+			// Skip empty lines, comments and lines without "="
+			if e == "" {
+				continue
+			}
+
+			if strings.HasPrefix(e, "#") || strings.HasPrefix(e, "//") {
+				continue
+			}
+
+			if !strings.Contains(e, "=") {
+				continue
+			}
+
 			parts := strings.Split(e, "=")
-			m[parts[0]] = parts[1]
+			m[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 		}
 		jsonString, _ := json.MarshalIndent(m, "", "  ")
 
@@ -51,7 +65,7 @@ var keyValueToJson = &cobra.Command{
 		// Write the output file
 		file, err := os.Create(outputJsonFile1)
 		checkNilErr(err)
-		
+
 		defer file.Close()
 
 		_, err = file.WriteString(string(jsonString))


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Closes #15 

## 👨‍💻 Changes proposed

`KVTJ` command will now be able to handle empty lines and the key value without an `=`. Additionally, if the line is commented on `#` or `//` it will skip it
